### PR TITLE
upgraded arrow from 0.9.0 to 0.10.0:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,28 +23,19 @@ apply plugin: 'kotlin-kapt'
 group 'propCheck'
 version '0.9.3'
 
-def arrow_version = "0.9.0"
+def arrow_version = "0.10.0"
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.3.21" // For forAll instance lookups
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
     implementation "org.apache.commons:commons-math3:3.6.1" // For floating point error function
 
-    kapt "io.arrow-kt:arrow-meta:$arrow_version" // auto generation for @extension @optics and @higherkind
-    implementation "io.arrow-kt:arrow-annotations:$arrow_version" // arrow annotations @extension and @higherkind
-    implementation "io.arrow-kt:arrow-core-data:$arrow_version" // Option/Either ...
+    kapt "io.arrow-kt:arrow-meta:$arrow_version" // auto generation for @extension and @higherkind
+
+    implementation "io.arrow-kt:arrow-fx:$arrow_version" // IO and arrow fx
+    implementation "io.arrow-kt:arrow-optics:$arrow_version" // lenses and @optics                
     implementation "io.arrow-kt:arrow-syntax:$arrow_version" // helper functions like curried...
-    implementation "io.arrow-kt:arrow-typeclasses:$arrow_version" // arrows typeclasses
-    implementation "io.arrow-kt:arrow-extras-data:$arrow_version" // Mtl + collection wrappers
-    implementation "io.arrow-kt:arrow-core-extensions:$arrow_version" // instances for typeclasses for datatypes in core-data
-    implementation "io.arrow-kt:arrow-extras-extensions:$arrow_version" // instances for typeclasses for datatypes in extras
-    implementation "io.arrow-kt:arrow-generic:$arrow_version" // @optics and some generic helpers
-    implementation "io.arrow-kt:arrow-effects-data:$arrow_version" // IO and arrow fx
-    implementation "io.arrow-kt:arrow-effects-extensions:$arrow_version" // instances ^^
-    implementation "io.arrow-kt:arrow-effects-io-extensions:$arrow_version" // instances ^^
-    implementation "io.arrow-kt:arrow-free-data:$arrow_version" // Free monads mainly for bindingStacksafe
-    implementation "io.arrow-kt:arrow-free-extensions:$arrow_version" // instances ^^
-    implementation "io.arrow-kt:arrow-optics:$arrow_version" // lenses
+    implementation "io.arrow-kt:arrow-mtl:$arrow_version" // StateT, Reader, Writer...
 
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.2.1"
     testImplementation "io.arrow-kt:arrow-test:$arrow_version" // test helpers and laws

--- a/generator-scripts/tuple.generator.kts
+++ b/generator-scripts/tuple.generator.kts
@@ -51,7 +51,7 @@ for (i in 2..maxTuple) {
         fileContent.append("    fun A${l.toUpperCase()}(): Arbitrary<${l.toUpperCase()}>").append("\n")
     }
 
-    fileContent.append("    override fun arbitrary(): Gen<Tuple${i}${diamond1}> = Gen.monad().binding {").append("\n")
+    fileContent.append("    override fun arbitrary(): Gen<Tuple${i}${diamond1}> = Gen.monad().fx.monad {").append("\n")
     fileContent.append("        Tuple${i}(AA().arbitrary().bind()")
     letters.drop(1).forEach { l ->
         fileContent.append(", A${l.toUpperCase()}().arbitrary().bind()")

--- a/src/main/kotlin/propCheck/Boolean.kt
+++ b/src/main/kotlin/propCheck/Boolean.kt
@@ -2,7 +2,7 @@ package propCheck
 
 import arrow.core.Eval
 import arrow.core.Tuple2
-import arrow.effects.IO
+import arrow.fx.IO
 import arrow.syntax.function.andThen
 import arrow.typeclasses.Show
 

--- a/src/main/kotlin/propCheck/Reflection.kt
+++ b/src/main/kotlin/propCheck/Reflection.kt
@@ -2,10 +2,9 @@ package propCheck
 
 import arrow.core.*
 import arrow.core.extensions.show
-import arrow.data.*
-import arrow.effects.IO
-import arrow.effects.extensions.io.applicativeError.handleError
-import arrow.effects.extensions.io.monadThrow.monadThrow
+import arrow.fx.IO
+import arrow.fx.extensions.io.applicativeError.handleError
+import arrow.fx.extensions.io.monadThrow.monadThrow
 import arrow.typeclasses.Show
 import propCheck.arbitrary.*
 import propCheck.arbitrary.asciistring.arbitrary.arbitrary
@@ -14,6 +13,20 @@ import propCheck.arbitrary.blind.arbitrary.arbitrary
 import propCheck.arbitrary.blind.show.show
 import propCheck.arbitrary.fixed.arbitrary.arbitrary
 import propCheck.arbitrary.fixed.show.show
+import propCheck.arbitrary.negative.arbitrary.arbitrary
+import propCheck.arbitrary.negative.show.show
+import propCheck.arbitrary.nonnegative.arbitrary.arbitrary
+import propCheck.arbitrary.nonnegative.show.show
+import propCheck.arbitrary.nonpositive.arbitrary.arbitrary
+import propCheck.arbitrary.nonpositive.show.show
+import propCheck.arbitrary.positive.arbitrary.arbitrary
+import propCheck.arbitrary.positive.show.show
+import propCheck.arbitrary.shrink2.arbitrary.arbitrary
+import propCheck.arbitrary.shrink2.show.show
+import propCheck.arbitrary.smart.arbitrary.arbitrary
+import propCheck.arbitrary.smart.show.show
+import propCheck.arbitrary.unicodestring.arbitrary.arbitrary
+import propCheck.arbitrary.unicodestring.show.show
 import propCheck.instances.*
 import propCheck.instances.either.arbitrary.arbitrary
 import propCheck.instances.id.arbitrary.arbitrary
@@ -45,20 +58,6 @@ import propCheck.instances.tuple7.arbitrary.arbitrary
 import propCheck.instances.tuple8.arbitrary.arbitrary
 import propCheck.instances.tuple9.arbitrary.arbitrary
 import propCheck.instances.validated.arbitrary.arbitrary
-import propCheck.arbitrary.negative.arbitrary.arbitrary
-import propCheck.arbitrary.negative.show.show
-import propCheck.arbitrary.nonnegative.arbitrary.arbitrary
-import propCheck.arbitrary.nonnegative.show.show
-import propCheck.arbitrary.nonpositive.arbitrary.arbitrary
-import propCheck.arbitrary.nonpositive.show.show
-import propCheck.arbitrary.positive.arbitrary.arbitrary
-import propCheck.arbitrary.positive.show.show
-import propCheck.arbitrary.shrink2.arbitrary.arbitrary
-import propCheck.arbitrary.shrink2.show.show
-import propCheck.arbitrary.smart.arbitrary.arbitrary
-import propCheck.arbitrary.smart.show.show
-import propCheck.arbitrary.unicodestring.arbitrary.arbitrary
-import propCheck.arbitrary.unicodestring.show.show
 import propCheck.property.testable.testable
 import propCheck.testresult.testable.testable
 import java.lang.reflect.ParameterizedType
@@ -123,7 +122,7 @@ fun <A : Any> lookupShow(qualifiedName: String): Show<A> = when (qualifiedName) 
     else -> Show.any()
 } as Show<A>
 
-inline fun <reified A : Any> defShow(): Show<A> = IO.monadThrow().bindingCatch {
+inline fun <reified A : Any> defShow(): Show<A> = IO.monadThrow().fx.monadThrow {
     Nel.fromList(getGenericTypes<A>()).fold({
         lookupShow<A>(A::class.qualifiedName!!)
     }, {

--- a/src/main/kotlin/propCheck/Unsafe.kt
+++ b/src/main/kotlin/propCheck/Unsafe.kt
@@ -7,7 +7,7 @@ import propCheck.arbitrary.Gen
 import propCheck.arbitrary.fix
 import propCheck.arbitrary.gen.monad.monad
 
-fun <F, A> Kind<F, Gen<A>>.promote(M: Monad<F>): Gen<Kind<F, A>> = Gen.monad().binding {
+fun <F, A> Kind<F, Gen<A>>.promote(M: Monad<F>): Gen<Kind<F, A>> = Gen.monad().fx.monad {
     val eval = delay<A>().bind()
     M.lift(eval).invoke(this@promote)
 }.fix()

--- a/src/main/kotlin/propCheck/arbitrary/Arbitrary.kt
+++ b/src/main/kotlin/propCheck/arbitrary/Arbitrary.kt
@@ -53,7 +53,7 @@ fun arbitrarySizedPositiveLong(): Gen<Long> = Gen.sized {
 }
 
 fun arbitrarySizedFloat(): Gen<Float> = Gen.sized { n ->
-    Gen.monad().binding {
+    Gen.monad().fx.monad {
         val b = Gen.choose(1L toT 999999999L, Long.random()).bind()
         val a = Gen.choose((-n) * b toT n * b, Long.random()).bind()
         a.toFloat() / b.toFloat()
@@ -61,7 +61,7 @@ fun arbitrarySizedFloat(): Gen<Float> = Gen.sized { n ->
 }
 
 fun arbitrarySizedDouble(): Gen<Double> = Gen.sized { n ->
-    Gen.monad().binding {
+    Gen.monad().fx.monad {
         val b = Gen.choose(1L toT 999999999L, Long.random()).bind()
         val a = Gen.choose((-n) * b toT n * b, Long.random()).bind()
         a.toDouble() / b.toDouble()

--- a/src/main/kotlin/propCheck/arbitrary/HelperClasses.kt
+++ b/src/main/kotlin/propCheck/arbitrary/HelperClasses.kt
@@ -1,14 +1,14 @@
 package propCheck.arbitrary
 
 import arrow.Kind
+import arrow.core.ListK
 import arrow.core.Tuple2
 import arrow.core.extensions.eq
+import arrow.core.extensions.list.eq.eqv
+import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.order
-import arrow.data.ListK
-import arrow.data.extensions.list.eq.eqv
-import arrow.data.extensions.listk.eq.eq
-import arrow.data.extensions.sequence.foldable.isEmpty
-import arrow.data.k
+import arrow.core.extensions.sequence.foldable.isEmpty
+import arrow.core.k
 import arrow.extension
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Functor

--- a/src/main/kotlin/propCheck/instances/Ior.kt
+++ b/src/main/kotlin/propCheck/instances/Ior.kt
@@ -1,8 +1,8 @@
 package propCheck.instances
 
-import arrow.data.Ior
-import arrow.data.leftIor
-import arrow.data.rightIor
+import arrow.core.Ior
+import arrow.core.leftIor
+import arrow.core.rightIor
 import arrow.extension
 import arrow.typeclasses.Show
 import propCheck.arbitrary.Arbitrary

--- a/src/main/kotlin/propCheck/instances/ListK.kt
+++ b/src/main/kotlin/propCheck/instances/ListK.kt
@@ -1,7 +1,7 @@
 package propCheck.instances
 
-import arrow.data.ListK
-import arrow.data.k
+import arrow.core.ListK
+import arrow.core.k
 import arrow.extension
 import arrow.typeclasses.Show
 import propCheck.arbitrary.Arbitrary

--- a/src/main/kotlin/propCheck/instances/MapK.kt
+++ b/src/main/kotlin/propCheck/instances/MapK.kt
@@ -1,15 +1,15 @@
 package propCheck.instances
 
+import arrow.core.MapK
 import arrow.core.Tuple2
+import arrow.core.mapOf
 import arrow.core.toT
-import arrow.data.MapK
-import arrow.data.mapOf
 import arrow.extension
 import arrow.typeclasses.Show
 import propCheck.arbitrary.Arbitrary
 import propCheck.arbitrary.Gen
-import propCheck.instances.tuple2.arbitrary.arbitrary
 import propCheck.arbitrary.shrinkList
+import propCheck.instances.tuple2.arbitrary.arbitrary
 
 @extension
 interface MapKArbitrary<K, V> : Arbitrary<MapK<K, V>> {

--- a/src/main/kotlin/propCheck/instances/NonEmptyList.kt
+++ b/src/main/kotlin/propCheck/instances/NonEmptyList.kt
@@ -1,7 +1,7 @@
 package propCheck.instances
 
-import arrow.data.Nel
-import arrow.data.NonEmptyList
+import arrow.core.Nel
+import arrow.core.NonEmptyList
 import arrow.extension
 import arrow.typeclasses.Show
 import propCheck.arbitrary.Arbitrary

--- a/src/main/kotlin/propCheck/instances/Prims.kt
+++ b/src/main/kotlin/propCheck/instances/Prims.kt
@@ -1,8 +1,8 @@
 package propCheck.instances
 
+import arrow.core.ListK
+import arrow.core.k
 import arrow.core.toT
-import arrow.data.ListK
-import arrow.data.k
 import propCheck.arbitrary.*
 import propCheck.arbitrary.gen.monad.monad
 import propCheck.instances.listk.arbitrary.arbitrary
@@ -82,7 +82,7 @@ fun String.Companion.arbitrary(): Arbitrary<String> = object :
 val intArrayArb = object : Arbitrary<IntArray> {
     val intArb = Int.arbitrary()
     override fun arbitrary(): Gen<IntArray> = Gen.sized {
-        Gen.monad().binding {
+        Gen.monad().fx.monad {
             IntArray(it) { intArb.arbitrary().bind() }
         }.fix()
     }
@@ -97,7 +97,7 @@ val intArrayArb = object : Arbitrary<IntArray> {
 val longArrayArb = object : Arbitrary<LongArray> {
     val longArb = Long.arbitrary()
     override fun arbitrary(): Gen<LongArray> = Gen.sized {
-        Gen.monad().binding {
+        Gen.monad().fx.monad {
             LongArray(it) { longArb.arbitrary().bind() }
         }.fix()
     }
@@ -112,7 +112,7 @@ val longArrayArb = object : Arbitrary<LongArray> {
 val floatArrayArb = object : Arbitrary<FloatArray> {
     val floatArb = Float.arbitrary()
     override fun arbitrary(): Gen<FloatArray> = Gen.sized {
-        Gen.monad().binding {
+        Gen.monad().fx.monad {
             FloatArray(it) { floatArb.arbitrary().bind() }
         }.fix()
     }
@@ -127,7 +127,7 @@ val floatArrayArb = object : Arbitrary<FloatArray> {
 val doubleArrayArb = object : Arbitrary<DoubleArray> {
     val doubleArb = Double.arbitrary()
     override fun arbitrary(): Gen<DoubleArray> = Gen.sized {
-        Gen.monad().binding {
+        Gen.monad().fx.monad {
             DoubleArray(it) { doubleArb.arbitrary().bind() }
         }.fix()
     }
@@ -142,7 +142,7 @@ val doubleArrayArb = object : Arbitrary<DoubleArray> {
 val byteArrayArb = object : Arbitrary<ByteArray> {
     val byteArb = Byte.arbitrary()
     override fun arbitrary(): Gen<ByteArray> = Gen.sized {
-        Gen.monad().binding {
+        Gen.monad().fx.monad {
             ByteArray(it) { byteArb.arbitrary().bind() }
         }.fix()
     }
@@ -157,7 +157,7 @@ val byteArrayArb = object : Arbitrary<ByteArray> {
 val booleanArrayArb = object : Arbitrary<BooleanArray> {
     val booleanArb = Boolean.arbitrary()
     override fun arbitrary(): Gen<BooleanArray> = Gen.sized {
-        Gen.monad().binding {
+        Gen.monad().fx.monad {
             BooleanArray(it) { booleanArb.arbitrary().bind() }
         }.fix()
     }

--- a/src/main/kotlin/propCheck/instances/SetK.kt
+++ b/src/main/kotlin/propCheck/instances/SetK.kt
@@ -1,7 +1,7 @@
 package propCheck.instances
 
-import arrow.data.SetK
-import arrow.data.k
+import arrow.core.SetK
+import arrow.core.k
 import arrow.extension
 import arrow.typeclasses.Show
 import propCheck.arbitrary.Arbitrary

--- a/src/main/kotlin/propCheck/instances/Tuples.kt
+++ b/src/main/kotlin/propCheck/instances/Tuples.kt
@@ -38,7 +38,7 @@ import propCheck.arbitrary.shrinkMap
 interface Tuple2Arbitrary<A, B> : Arbitrary<Tuple2<A, B>> {
     fun AA(): Arbitrary<A>
     fun AB(): Arbitrary<B>
-    override fun arbitrary(): Gen<Tuple2<A, B>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple2<A, B>> = Gen.monad().fx.monad {
         Tuple2(AA().arbitrary().bind(), AB().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple2<A, B>): Sequence<Tuple2<A, B>> =
@@ -60,7 +60,7 @@ interface Tuple3Arbitrary<A, B, C> : Arbitrary<Tuple3<A, B, C>> {
     fun AA(): Arbitrary<A>
     fun AB(): Arbitrary<B>
     fun AC(): Arbitrary<C>
-    override fun arbitrary(): Gen<Tuple3<A, B, C>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple3<A, B, C>> = Gen.monad().fx.monad {
         Tuple3(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple3<A, B, C>): Sequence<Tuple3<A, B, C>> =
@@ -84,7 +84,7 @@ interface Tuple4Arbitrary<A, B, C, D> : Arbitrary<Tuple4<A, B, C, D>> {
     fun AB(): Arbitrary<B>
     fun AC(): Arbitrary<C>
     fun AD(): Arbitrary<D>
-    override fun arbitrary(): Gen<Tuple4<A, B, C, D>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple4<A, B, C, D>> = Gen.monad().fx.monad {
         Tuple4(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple4<A, B, C, D>): Sequence<Tuple4<A, B, C, D>> =
@@ -111,7 +111,7 @@ interface Tuple5Arbitrary<A, B, C, D, E> : Arbitrary<Tuple5<A, B, C, D, E>> {
     fun AC(): Arbitrary<C>
     fun AD(): Arbitrary<D>
     fun AE(): Arbitrary<E>
-    override fun arbitrary(): Gen<Tuple5<A, B, C, D, E>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple5<A, B, C, D, E>> = Gen.monad().fx.monad {
         Tuple5(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple5<A, B, C, D, E>): Sequence<Tuple5<A, B, C, D, E>> =
@@ -141,7 +141,7 @@ interface Tuple6Arbitrary<A, B, C, D, E, F> : Arbitrary<Tuple6<A, B, C, D, E, F>
     fun AD(): Arbitrary<D>
     fun AE(): Arbitrary<E>
     fun AF(): Arbitrary<F>
-    override fun arbitrary(): Gen<Tuple6<A, B, C, D, E, F>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple6<A, B, C, D, E, F>> = Gen.monad().fx.monad {
         Tuple6(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple6<A, B, C, D, E, F>): Sequence<Tuple6<A, B, C, D, E, F>> =
@@ -174,7 +174,7 @@ interface Tuple7Arbitrary<A, B, C, D, E, F, G> : Arbitrary<Tuple7<A, B, C, D, E,
     fun AE(): Arbitrary<E>
     fun AF(): Arbitrary<F>
     fun AG(): Arbitrary<G>
-    override fun arbitrary(): Gen<Tuple7<A, B, C, D, E, F, G>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple7<A, B, C, D, E, F, G>> = Gen.monad().fx.monad {
         Tuple7(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple7<A, B, C, D, E, F, G>): Sequence<Tuple7<A, B, C, D, E, F, G>> =
@@ -210,7 +210,7 @@ interface Tuple8Arbitrary<A, B, C, D, E, F, G, H> : Arbitrary<Tuple8<A, B, C, D,
     fun AF(): Arbitrary<F>
     fun AG(): Arbitrary<G>
     fun AH(): Arbitrary<H>
-    override fun arbitrary(): Gen<Tuple8<A, B, C, D, E, F, G, H>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple8<A, B, C, D, E, F, G, H>> = Gen.monad().fx.monad {
         Tuple8(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple8<A, B, C, D, E, F, G, H>): Sequence<Tuple8<A, B, C, D, E, F, G, H>> =
@@ -250,7 +250,7 @@ interface Tuple9Arbitrary<A, B, C, D, E, F, G, H, I> :
     fun AG(): Arbitrary<G>
     fun AH(): Arbitrary<H>
     fun AI(): Arbitrary<I>
-    override fun arbitrary(): Gen<Tuple9<A, B, C, D, E, F, G, H, I>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple9<A, B, C, D, E, F, G, H, I>> = Gen.monad().fx.monad {
         Tuple9(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple9<A, B, C, D, E, F, G, H, I>): Sequence<Tuple9<A, B, C, D, E, F, G, H, I>> =
@@ -293,7 +293,7 @@ interface Tuple10Arbitrary<A, B, C, D, E, F, G, H, I, J> :
     fun AH(): Arbitrary<H>
     fun AI(): Arbitrary<I>
     fun AJ(): Arbitrary<J>
-    override fun arbitrary(): Gen<Tuple10<A, B, C, D, E, F, G, H, I, J>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple10<A, B, C, D, E, F, G, H, I, J>> = Gen.monad().fx.monad {
         Tuple10(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple10<A, B, C, D, E, F, G, H, I, J>): Sequence<Tuple10<A, B, C, D, E, F, G, H, I, J>> =
@@ -339,7 +339,7 @@ interface Tuple11Arbitrary<A, B, C, D, E, F, G, H, I, J, K> :
     fun AI(): Arbitrary<I>
     fun AJ(): Arbitrary<J>
     fun AK(): Arbitrary<K>
-    override fun arbitrary(): Gen<Tuple11<A, B, C, D, E, F, G, H, I, J, K>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple11<A, B, C, D, E, F, G, H, I, J, K>> = Gen.monad().fx.monad {
         Tuple11(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple11<A, B, C, D, E, F, G, H, I, J, K>): Sequence<Tuple11<A, B, C, D, E, F, G, H, I, J, K>> =
@@ -388,7 +388,7 @@ interface Tuple12Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L> :
     fun AJ(): Arbitrary<J>
     fun AK(): Arbitrary<K>
     fun AL(): Arbitrary<L>
-    override fun arbitrary(): Gen<Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>> = Gen.monad().fx.monad {
         Tuple12(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>): Sequence<Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>> =
@@ -440,7 +440,7 @@ interface Tuple13Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M> :
     fun AK(): Arbitrary<K>
     fun AL(): Arbitrary<L>
     fun AM(): Arbitrary<M>
-    override fun arbitrary(): Gen<Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>> = Gen.monad().fx.monad {
         Tuple13(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>): Sequence<Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>> =
@@ -495,7 +495,7 @@ interface Tuple14Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M, N> :
     fun AL(): Arbitrary<L>
     fun AM(): Arbitrary<M>
     fun AN(): Arbitrary<N>
-    override fun arbitrary(): Gen<Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>> = Gen.monad().fx.monad {
         Tuple14(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind(), AN().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>): Sequence<Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>> =
@@ -553,7 +553,7 @@ interface Tuple15Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> :
     fun AM(): Arbitrary<M>
     fun AN(): Arbitrary<N>
     fun AO(): Arbitrary<O>
-    override fun arbitrary(): Gen<Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>> = Gen.monad().fx.monad {
         Tuple15(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind(), AN().arbitrary().bind(), AO().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>): Sequence<Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>> =
@@ -614,7 +614,7 @@ interface Tuple16Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> :
     fun AN(): Arbitrary<N>
     fun AO(): Arbitrary<O>
     fun AP(): Arbitrary<P>
-    override fun arbitrary(): Gen<Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>> = Gen.monad().fx.monad {
         Tuple16(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind(), AN().arbitrary().bind(), AO().arbitrary().bind(), AP().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>): Sequence<Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>> =
@@ -678,7 +678,7 @@ interface Tuple17Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> :
     fun AO(): Arbitrary<O>
     fun AP(): Arbitrary<P>
     fun AQ(): Arbitrary<Q>
-    override fun arbitrary(): Gen<Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>> = Gen.monad().fx.monad {
         Tuple17(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind(), AN().arbitrary().bind(), AO().arbitrary().bind(), AP().arbitrary().bind(), AQ().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>): Sequence<Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>> =
@@ -745,7 +745,7 @@ interface Tuple18Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>
     fun AP(): Arbitrary<P>
     fun AQ(): Arbitrary<Q>
     fun AR(): Arbitrary<R>
-    override fun arbitrary(): Gen<Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>> = Gen.monad().fx.monad {
         Tuple18(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind(), AN().arbitrary().bind(), AO().arbitrary().bind(), AP().arbitrary().bind(), AQ().arbitrary().bind(), AR().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>): Sequence<Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>> =
@@ -815,7 +815,7 @@ interface Tuple19Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R,
     fun AQ(): Arbitrary<Q>
     fun AR(): Arbitrary<R>
     fun AS(): Arbitrary<S>
-    override fun arbitrary(): Gen<Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>> = Gen.monad().fx.monad {
         Tuple19(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind(), AN().arbitrary().bind(), AO().arbitrary().bind(), AP().arbitrary().bind(), AQ().arbitrary().bind(), AR().arbitrary().bind(), AS().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>): Sequence<Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>> =
@@ -888,7 +888,7 @@ interface Tuple20Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R,
     fun AR(): Arbitrary<R>
     fun AS(): Arbitrary<S>
     fun AT(): Arbitrary<T>
-    override fun arbitrary(): Gen<Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>> = Gen.monad().fx.monad {
         Tuple20(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind(), AN().arbitrary().bind(), AO().arbitrary().bind(), AP().arbitrary().bind(), AQ().arbitrary().bind(), AR().arbitrary().bind(), AS().arbitrary().bind(), AT().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>): Sequence<Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>> =
@@ -964,7 +964,7 @@ interface Tuple21Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R,
     fun AS(): Arbitrary<S>
     fun AT(): Arbitrary<T>
     fun AU(): Arbitrary<U>
-    override fun arbitrary(): Gen<Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>> = Gen.monad().fx.monad {
         Tuple21(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind(), AN().arbitrary().bind(), AO().arbitrary().bind(), AP().arbitrary().bind(), AQ().arbitrary().bind(), AR().arbitrary().bind(), AS().arbitrary().bind(), AT().arbitrary().bind(), AU().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>): Sequence<Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>> =
@@ -1043,7 +1043,7 @@ interface Tuple22Arbitrary<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R,
     fun AT(): Arbitrary<T>
     fun AU(): Arbitrary<U>
     fun AV(): Arbitrary<V>
-    override fun arbitrary(): Gen<Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>> = Gen.monad().binding {
+    override fun arbitrary(): Gen<Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>> = Gen.monad().fx.monad {
         Tuple22(AA().arbitrary().bind(), AB().arbitrary().bind(), AC().arbitrary().bind(), AD().arbitrary().bind(), AE().arbitrary().bind(), AF().arbitrary().bind(), AG().arbitrary().bind(), AH().arbitrary().bind(), AI().arbitrary().bind(), AJ().arbitrary().bind(), AK().arbitrary().bind(), AL().arbitrary().bind(), AM().arbitrary().bind(), AN().arbitrary().bind(), AO().arbitrary().bind(), AP().arbitrary().bind(), AQ().arbitrary().bind(), AR().arbitrary().bind(), AS().arbitrary().bind(), AT().arbitrary().bind(), AU().arbitrary().bind(), AV().arbitrary().bind())
     }.fix()
     override fun shrink(fail: Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>): Sequence<Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>> =

--- a/src/main/kotlin/propCheck/instances/Validated.kt
+++ b/src/main/kotlin/propCheck/instances/Validated.kt
@@ -1,8 +1,8 @@
 package propCheck.instances
 
-import arrow.data.Validated
-import arrow.data.invalid
-import arrow.data.valid
+import arrow.core.Validated
+import arrow.core.invalid
+import arrow.core.valid
 import arrow.extension
 import arrow.typeclasses.Show
 import propCheck.arbitrary.Arbitrary

--- a/src/test/kotlin/propCheck/PropCheck.kt
+++ b/src/test/kotlin/propCheck/PropCheck.kt
@@ -4,11 +4,10 @@ import arrow.core.Eval
 import arrow.core.Tuple2
 import arrow.core.some
 import arrow.core.toT
-import arrow.effects.IO
-import arrow.effects.extensions.io.applicativeError.attempt
-import arrow.effects.extensions.io.monadThrow.monadThrow
+import arrow.fx.IO
+import arrow.fx.extensions.io.applicativeError.attempt
+import arrow.fx.extensions.io.monadThrow.monadThrow
 import propCheck.arbitrary.*
-import propCheck.instances.arbitrary
 
 class TestableSpec : PropertySpec({
     "Boolean should be lifted correctly" {
@@ -52,7 +51,7 @@ class PropCheckSpec : PropertySpec({
     "propCheck is the same as propCheckIOWithError.unsageRunSync()" {
         forAll { b: Boolean ->
             ioProperty(
-                IO.monadThrow().bindingCatch {
+                IO.monadThrow().fx.monadThrow {
                     propCheck(Args(replay = (RandSeed(0L) toT 0).some(), maxSuccess = 1)) {
                         Boolean.testable().run { b.property() }
                     }

--- a/src/test/kotlin/propCheck/Reflection.kt
+++ b/src/test/kotlin/propCheck/Reflection.kt
@@ -1,12 +1,18 @@
 package propCheck
 
 import arrow.core.*
-import arrow.data.*
 import io.kotlintest.specs.WordSpec
 import propCheck.arbitrary.*
 import propCheck.arbitrary.asciistring.arbitrary.arbitrary
 import propCheck.arbitrary.blind.arbitrary.arbitrary
 import propCheck.arbitrary.fixed.arbitrary.arbitrary
+import propCheck.arbitrary.negative.arbitrary.arbitrary
+import propCheck.arbitrary.nonnegative.arbitrary.arbitrary
+import propCheck.arbitrary.nonpositive.arbitrary.arbitrary
+import propCheck.arbitrary.positive.arbitrary.arbitrary
+import propCheck.arbitrary.shrink2.arbitrary.arbitrary
+import propCheck.arbitrary.smart.arbitrary.arbitrary
+import propCheck.arbitrary.unicodestring.arbitrary.arbitrary
 import propCheck.instances.*
 import propCheck.instances.either.arbitrary.arbitrary
 import propCheck.instances.id.arbitrary.arbitrary
@@ -19,13 +25,6 @@ import propCheck.instances.setk.arbitrary.arbitrary
 import propCheck.instances.tuple2.arbitrary.arbitrary
 import propCheck.instances.tuple4.arbitrary.arbitrary
 import propCheck.instances.validated.arbitrary.arbitrary
-import propCheck.arbitrary.negative.arbitrary.arbitrary
-import propCheck.arbitrary.nonnegative.arbitrary.arbitrary
-import propCheck.arbitrary.nonpositive.arbitrary.arbitrary
-import propCheck.arbitrary.positive.arbitrary.arbitrary
-import propCheck.arbitrary.shrink2.arbitrary.arbitrary
-import propCheck.arbitrary.smart.arbitrary.arbitrary
-import propCheck.arbitrary.unicodestring.arbitrary.arbitrary
 
 class ReflectionSpec : WordSpec({
     "reflection should be able to lookup " should {

--- a/src/test/kotlin/propCheck/State.kt
+++ b/src/test/kotlin/propCheck/State.kt
@@ -2,11 +2,11 @@ package propCheck
 
 import arrow.core.Eval
 import arrow.core.some
-import arrow.effects.ForIO
-import arrow.effects.IO
-import arrow.effects.Ref
-import arrow.effects.extensions.io.monadDefer.monadDefer
-import arrow.effects.fix
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.Ref
+import arrow.fx.extensions.io.monadDefer.monadDefer
+import arrow.fx.fix
 import propCheck.arbitrary.Gen
 
 // -----------
@@ -93,7 +93,7 @@ class StateSpec : PropertySpec({
                     is ACT.Get -> s.get().fix()
                 }
             },
-            sut = { Ref.of(0, IO.monadDefer()).fix() },
+            sut = { Ref(IO.monadDefer(), 0).fix() },
             cmdGen = {
                 Gen.elements(
                     ACT.Inc,

--- a/src/test/kotlin/propCheck/arbitrary/GenLaws.kt
+++ b/src/test/kotlin/propCheck/arbitrary/GenLaws.kt
@@ -1,9 +1,8 @@
 package propCheck.arbitrary
 
-import arrow.core.Option
+import arrow.core.Nel
 import arrow.core.Tuple2
 import arrow.core.toT
-import arrow.data.Nel
 import arrow.test.laws.MonadLaws
 import arrow.typeclasses.Eq
 import propCheck.*

--- a/src/test/kotlin/propCheck/arbitrary/HelperClasses.kt
+++ b/src/test/kotlin/propCheck/arbitrary/HelperClasses.kt
@@ -1,19 +1,18 @@
 package propCheck.arbitrary
 
+import arrow.core.ListK
 import arrow.core.Tuple2
 import arrow.core.extensions.eq
+import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.order
+import arrow.core.k
 import arrow.core.toT
-import arrow.data.ListK
-import arrow.data.extensions.listk.eq.eq
-import arrow.data.k
 import arrow.test.laws.FunctorLaws
 import arrow.typeclasses.Eq
 import propCheck.*
 import propCheck.arbitrary.blind.eq.eq
 import propCheck.arbitrary.blind.functor.functor
 import propCheck.arbitrary.blind.show.show
-import propCheck.instances.arbitrary
 import propCheck.arbitrary.negative.arbitrary.arbitrary
 import propCheck.arbitrary.negative.eq.eq
 import propCheck.arbitrary.negative.functor.functor
@@ -35,6 +34,7 @@ import propCheck.arbitrary.shrink2.functor.functor
 import propCheck.arbitrary.shrinking.arbitrary.arbitrary
 import propCheck.arbitrary.shrinking.functor.functor
 import propCheck.arbitrary.smart.functor.functor
+import propCheck.instances.arbitrary
 
 class BlindSpec : LawSpec() {
     init {


### PR DESCRIPTION
- migrated the imports from arrow.data.* to arrow.core.*
- migrated the imports from arrow.effects.* to arrow.fx.*
- migrated the calls `monad().binding` to `monad().fx.monad` for Gen and Rose
- migrated the call `Gen.monad().bindingStackSafe` to `Gen.monad().fx.monad`
- migrated `IO.monad().binding` to `IO.fx`
- migrated `Eval.monad().binding` to `Eval.fx`
- migrated `IO.monadThrow().bindingCatch` to `IO.monadThrow().fx.monadThrow`
- migrated import `arrow.data.StateT` to `arrow.mtl.StateT`